### PR TITLE
Set defaults for Builder

### DIFF
--- a/lib/puppet/modulebuilder/builder.rb
+++ b/lib/puppet/modulebuilder/builder.rb
@@ -19,7 +19,7 @@ module Puppet::Modulebuilder
 
     attr_reader :logger
 
-    def initialize(source, destination, logger)
+    def initialize(source, destination = nil, logger = nil)
       raise ArgumentError, 'logger is expected to be nil or a Logger. Got %{klass}' % { klass: logger.class } unless logger.nil? || logger.is_a?(Logger)
 
       @source_validated = false


### PR DESCRIPTION
These values are accepted and are sane values. This makes it easier to call.