### PR TITLE
Mock with kwargs as well

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ language: ruby
 cache: bundler
 jobs:
   include:
+  - rvm: 2.7.1
   - rvm: 2.5.7
     env:
     - SIMPLECOV=yes

--- a/Gemfile
+++ b/Gemfile
@@ -17,13 +17,14 @@ group :development do
     gem 'simplecov-console', '~> 0.6'
   end
 
-  if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.5.0')
-    gem 'puppet', '~> 6.0'
-  elsif Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.4.0')
-    gem 'puppet', '~> 5.0' # rubocop:disable Bundler/DuplicatedGem Nope, not a duplicate!
-  else
-    gem 'puppet', '~> 4.0' # rubocop:disable Bundler/DuplicatedGem Nope, not a duplicate!
-  end
+  puppet_version = if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.5.0')
+                     '~> 6.0'
+                   elsif Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.4.0')
+                     '~> 5.0'
+                   else
+                     '~> 4.0'
+                   end
+  gem 'puppet', puppet_version
 end
 
 # Evaluate Gemfile.local and ~/.gemfile if they exist

--- a/lib/puppet/modulebuilder/builder.rb
+++ b/lib/puppet/modulebuilder/builder.rb
@@ -383,32 +383,32 @@ module Puppet::Modulebuilder
 
     # Filesystem wrapper methods.
     # These are mocked in spec tests.
-    def file_exists?(*args)
-      File.file?(*args)
+    def file_exists?(*args, **kwargs)
+      File.file?(*args, **kwargs)
     end
 
-    def file_readable?(*args)
-      File.readable?(*args)
+    def file_readable?(*args, **kwargs)
+      File.readable?(*args, **kwargs)
     end
 
-    def file_directory?(*args)
-      File.directory?(*args)
+    def file_directory?(*args, **kwargs)
+      File.directory?(*args, **kwargs)
     end
 
-    def file_symlink?(*args)
-      File.symlink?(*args)
+    def file_symlink?(*args, **kwargs)
+      File.symlink?(*args, **kwargs)
     end
 
-    def fileutils_cp(*args)
-      FileUtils.cp(*args)
+    def fileutils_cp(*args, **kwargs)
+      FileUtils.cp(*args, **kwargs)
     end
 
-    def fileutils_mkdir_p(*args)
-      FileUtils.mkdir_p(*args)
+    def fileutils_mkdir_p(*args, **kwargs)
+      FileUtils.mkdir_p(*args, **kwargs)
     end
 
-    def file_stat(*args)
-      File.stat(*args)
+    def file_stat(*args, **kwargs)
+      File.stat(*args, **kwargs)
     end
   end
 end


### PR DESCRIPTION
In Ruby 2.7 sending the last arguments as a hash leads to a deprecation warning. By accepting the keyword arguments, the methods are fully wrapped.