### PR TITLE
Always ignore .git

### DIFF
--- a/lib/puppet/modulebuilder/builder.rb
+++ b/lib/puppet/modulebuilder/builder.rb
@@ -6,6 +6,7 @@ module Puppet::Modulebuilder
   # Class to build Puppet Modules from source
   class Builder
     DEFAULT_IGNORED = [
+      '/.git',
       '/pkg/',
       '~*',
       '/coverage',


### PR DESCRIPTION
At least PMT used to do this. By leaving this out, I accidentally released a module with my .git directory. In this case it wasn't a huge issue, but outside of the size impact, it can be a security issue.