### PR TITLE
Preserve directory mtimes

### DIFF
--- a/spec/unit/puppet/modulebuilder/builder_spec.rb
+++ b/spec/unit/puppet/modulebuilder/builder_spec.rb
@@ -103,6 +103,10 @@ RSpec.describe Puppet::Modulebuilder::Builder do
       allow(builder).to receive(:ignored_files).and_return(PathSpec.new("/spec/\n"))
       require 'find'
       allow(Find).to receive(:find).with(module_source).and_yield(found_file)
+      if found_file != module_source
+        allow(builder).to receive(:file_directory?).with(found_file).and_return(false)
+      end
+      allow(builder).to receive(:copy_mtime).with(module_source)
     end
 
     after(:each) do


### PR DESCRIPTION
To make module building more idempotent, this copies directory mtimes after copying files. The result is that when removing the staging directory and creating another the mtimes will be the same.

Since creating or removing a file modifies a directory, it needs to happen after all files have been copied.

This can be beneficial when using rsync to deploy.