### PR TITLE
Add a setter for release_name

### DIFF
--- a/lib/puppet/modulebuilder/builder.rb
+++ b/lib/puppet/modulebuilder/builder.rb
@@ -321,16 +321,22 @@ module Puppet::Modulebuilder
       file_exists?(package_file)
     end
 
-    # Combine the module name and version into a Forge-compatible dash
-    # separated string.
+    # The release name is used for the build directory and resulting package
+    # file.
     #
-    # @return [String] The module name and version, joined by a dash.
+    # The default combines the module name and version into a Forge-compatible
+    # dash separated string. Unless you have an unusual use case this isn't set
+    # manually.
+    #
+    # @return [String]
     def release_name
       @release_name ||= [
         metadata['name'],
         metadata['version'],
       ].join('-')
     end
+
+    attr_writer :release_name
 
     # Checks if the path length will fit into the POSIX.1-1998 (ustar) tar
     # header format.

--- a/lib/puppet/modulebuilder/builder.rb
+++ b/lib/puppet/modulebuilder/builder.rb
@@ -53,7 +53,9 @@ module Puppet::Modulebuilder
     end
 
     # Return the path to the temporary build directory, which will be placed
-    # inside the target directory and match the release name (see #release_name).
+    # inside the target directory and match the release name
+    #
+    # @see #release_name
     def build_dir
       @build_dir ||= File.join(build_context[:parent_dir], build_context[:build_dir_name])
     end

--- a/spec/unit/puppet/modulebuilder/builder_spec.rb
+++ b/spec/unit/puppet/modulebuilder/builder_spec.rb
@@ -147,7 +147,7 @@ RSpec.describe Puppet::Modulebuilder::Builder do
     let(:release_name) { 'my-module-0.0.1' }
 
     before(:each) do
-      allow(builder).to receive(:release_name).and_return(release_name)
+      builder.release_name = release_name
     end
 
     context 'when the path contains non-ASCII characters' do


### PR DESCRIPTION
I would like to be able to build to target/modules/apache instead of target/modules/puppetlabs-apache-1.2.3. I can achieve target/modules instead of ./pkg via the destination constructor argument, but the release name is not configurable. It can only be set via an instance variable. This setter adds a formal API.

Fixes #28