### PR TITLE
Store Ruby version as a Gem::Version in a var

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,9 +6,11 @@ source 'https://rubygems.org'
 gemspec
 
 group :development do
+  ruby_version = Gem::Version.new(RUBY_VERSION)
+
   gem 'rake', '~> 12.0'
   gem 'rspec', '~> 3.0'
-  if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.3.0')
+  if ruby_version >= Gem::Version.new('2.3.0')
     gem 'rubocop', ['~> 0.68', '< 0.82.0']
     gem 'rubocop-rspec', '~> 1.38'
 
@@ -18,11 +20,11 @@ group :development do
     gem 'simplecov-console', '~> 0.6'
   end
 
-  puppet_version = if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.7.0')
+  puppet_version = if ruby_version >= Gem::Version.new('2.7.0')
                      '~> 7.0'
-                   elsif Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.5.0')
+                   elsif ruby_version >= Gem::Version.new('2.5.0')
                      '~> 6.0'
-                   elsif Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.4.0')
+                   elsif ruby_version >= Gem::Version.new('2.4.0')
                      '~> 5.0'
                    else
                      '~> 4.0'


### PR DESCRIPTION
This reuses the variable to avoid duplicate instances. Also avoids the .dup since it's not like Gem::Version modifies the constant.