### PR TITLE
(CAT-1688) Upgrade rubocop to `~> 1.50.0`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ group :development do
   gem 'rake'
   gem 'rspec', '~> 3.1'
 
-  gem 'rubocop', '~> 1.48', require: false
+  gem 'rubocop', '~> 1.50.0', require: false
   gem 'rubocop-performance', '~> 1.16', require: false
   gem 'rubocop-rspec', '~> 2.19', require: false
 


### PR DESCRIPTION
Following a recent team decision, we are implementing a Rubocop Upgrade, moving the version from 1.48.1 to 1.50.0. This should be the final version until Puppet 7 is unsupported.

