### PR TITLE
Revert "(maint) Exclude breaking rubocop versions"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,8 +27,6 @@ group :development do
   gem 'rubocop', '~> 1.50.0', require: false
   gem 'rubocop-performance', '~> 1.16', require: false
   gem 'rubocop-rspec', '~> 2.19', require: false
-  gem 'rubocop-factory_bot', '!= 2.26.0', require: false
-  gem 'rubocop-rspec_rails', '!= 2.29.0', require: false
 
   gem 'simplecov'
   gem 'simplecov-console'


### PR DESCRIPTION
Reverts puppetlabs/puppet-modulebuilder#80 because this isn't a Rails project and doesn't include factory_bot. These gems shouldn't be here.