### PR TITLE
(bug) - Add lib dir to built modules

### DIFF
--- a/lib/puppet/modulebuilder/builder.rb
+++ b/lib/puppet/modulebuilder/builder.rb
@@ -20,6 +20,7 @@ module Puppet::Modulebuilder
       '!/docs/**',
       '!/files/**',
       '!/hiera.yaml',
+      '!/lib/**',
       '!/locales/**',
       '!/manifests/**',
       '!/metadata.json',


### PR DESCRIPTION
## Summary
Prior to this PR, the lib dir would be missing from built modules. This meant any types/providers defined in lib/ were not included in the modules, resulting in broken installs.


Provide a detailed description of all the changes present in this pull request.

## Additional Context
Any module with custom type CI would fail as type was not known to puppet.
https://github.com/puppetlabs/puppetlabs-firewall/actions/runs/10913207968/job/30299482494#step:9:27
https://github.com/puppetlabs/puppetlabs-dsc_lite/actions/runs/10912992683

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
