### PR TITLE
(bug) - Include missing function, facts.d and example dirs in module builds

### DIFF
--- a/lib/puppet/modulebuilder/builder.rb
+++ b/lib/puppet/modulebuilder/builder.rb
@@ -19,6 +19,7 @@ module Puppet::Modulebuilder
       '!/data/**',
       '!/docs/**',
       '!/files/**',
+      '!/functions/**',
       '!/hiera.yaml',
       '!/lib/**',
       '!/locales/**',

--- a/lib/puppet/modulebuilder/builder.rb
+++ b/lib/puppet/modulebuilder/builder.rb
@@ -18,6 +18,8 @@ module Puppet::Modulebuilder
       '!/bolt_plugin.json',
       '!/data/**',
       '!/docs/**',
+      '!/examples/**',
+      '!/facts.d/**',
       '!/files/**',
       '!/functions/**',
       '!/hiera.yaml',


### PR DESCRIPTION
## Summary
Add missing function, facts.d and example dirs to module builds.

Now fully matches https://github.com/puppetlabs/puppet-specifications/blob/master/language/module.md

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
