### PR TITLE
(CAT-2051): Add 'tooling' folder to be included while packaging 'puppetlabs-kubernetes'

### DIFF
--- a/lib/puppet/modulebuilder/builder.rb
+++ b/lib/puppet/modulebuilder/builder.rb
@@ -32,6 +32,7 @@ module Puppet::Modulebuilder
       '!/tasks/**',
       '!/templates/**',
       '!/types/**',
+      '!/tooling/**',
     ].freeze
 
     attr_reader :destination, :logger


### PR DESCRIPTION
Added 'tooling' folder to be included while packaging 'puppetlabs-kubernetes'

This tooling folder is required while running the spec.