### PR TITLE
Revert "(CAT-2051): Add 'tooling' folder to be included while packaging 'puppetlabs-kubernetes'"

### DIFF
--- a/lib/puppet/modulebuilder/builder.rb
+++ b/lib/puppet/modulebuilder/builder.rb
@@ -32,7 +32,6 @@ module Puppet::Modulebuilder
       '!/tasks/**',
       '!/templates/**',
       '!/types/**',
-      '!/tooling/**',
     ].freeze
 
     attr_reader :destination, :logger


### PR DESCRIPTION
Reverts puppetlabs/puppet-modulebuilder#104

Further discussion with the team revealed this merge is not viable given recent commitments made towards the tool. Reverting this as it was merged under wrong assumptions.