### PR TITLE
(CAT-2281) Remove puppet 7 infrastructure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,11 +18,8 @@ jobs:
       fail-fast: false
       matrix:
         ruby_version:
-          - "2.7"
           - "3.2"
         include:
-          - ruby-version: '2.7'
-            puppet_gem_version: '~> 7.0'
           - ruby_version: '3.2'
             puppet_gem_version: '~> 8.0' # puppet8'
         runs_on:
@@ -42,11 +39,8 @@ jobs:
     strategy:
       matrix:
         ruby_version:
-          - "2.7"
           - "3.2"
         include:
-          - ruby-version: '2.7'
-            puppet_gem_version: '~> 7.0'
           - ruby_version: '3.2'
             puppet_gem_version: 'https://github.com/puppetlabs/puppet' # puppet8'
         runs_on:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -11,11 +11,8 @@ jobs:
       fail-fast: false
       matrix:
         ruby_version:
-          - "2.7"
           - "3.2"
         include:
-          - ruby-version: '2.7'
-            puppet_gem_version: '~> 7.0'
           - ruby_version: '3.2'
             puppet_gem_version: 'https://github.com/puppetlabs/puppet' # puppet8'
         runs_on:
@@ -34,11 +31,8 @@ jobs:
     strategy:
       matrix:
         ruby_version:
-          - "2.7"
           - "3.2"
         include:
-          - ruby-version: '2.7'
-            puppet_gem_version: '~> 7.0'
           - ruby_version: '3.2'
             puppet_gem_version: 'https://github.com/puppetlabs/puppet' # puppet8'
         runs_on:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,9 @@ inherit_from: .rubocop_todo.yml
 inherit_gem:
   voxpupuli-rubocop: rubocop.yml
 
+AllCops:
+  TargetRubyVersion: '3.1'
+
 # Disabled
 Style/ClassAndModuleChildren:
   Enabled: false

--- a/puppet-modulebuilder.gemspec
+++ b/puppet-modulebuilder.gemspec
@@ -29,5 +29,5 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'voxpupuli-rubocop', '~> 3.0.0'
 
-  spec.required_ruby_version = Gem::Requirement.new('>= 2.7.0')
+  spec.required_ruby_version = Gem::Requirement.new('>= 3.1.0')
 end

--- a/spec/fixtures/module/Gemfile
+++ b/spec/fixtures/module/Gemfile
@@ -14,8 +14,6 @@ def location_for(place_or_version, fake_version = nil)
 end
 
 group :development do
-  gem "json", '= 2.1.0',                           require: false if Gem::Requirement.create(['>= 2.5.0', '< 2.7.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
-  gem "json", '= 2.3.0',                           require: false if Gem::Requirement.create(['>= 2.7.0', '< 3.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "json", '= 2.5.1',                           require: false if Gem::Requirement.create(['>= 3.0.0', '< 3.0.5']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "json", '= 2.6.1',                           require: false if Gem::Requirement.create(['>= 3.1.0', '< 3.1.3']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "json", '= 2.6.3',                           require: false if Gem::Requirement.create(['>= 3.2.0', '< 4.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))


### PR DESCRIPTION
Puppet 7 is EOL. Therefore, we can remove the test infrastructure for it. This commit aims to clear up any testing/config infrastructure related to Puppet 7 and, by extension, Ruby 2.7.

